### PR TITLE
Rapport/onderliggende lagen

### DIFF
--- a/Reports/Report0045.py
+++ b/Reports/Report0045.py
@@ -1,0 +1,21 @@
+from DQReport import DQReport
+
+
+class Report0045:
+    def __init__(self):
+        self.report = None
+
+    def init_report(self):
+        self.report = DQReport(name='report0045',
+                               title='Een BitumineuzeLaag heeft steeds een ligtOp relatie naar een Onderbouw',
+                               spreadsheet_id='',
+                               datasource='Neo4J',
+                               persistent_column='C')
+
+        self.report.result_query = """
+        MATCH (b:BitumineuzeLaag)
+        WHERE NOT EXISTS((b)-[:LigtOp]->(:Onderbouw))
+        RETURN b.uuid as uuid, b.name as name"""
+
+    def run_report(self, sender):
+        self.report.run_report(sender=sender)

--- a/Reports/Report0045.py
+++ b/Reports/Report0045.py
@@ -13,9 +13,10 @@ class Report0045:
                                persistent_column='C')
 
         self.report.result_query = """
-        MATCH (b:BitumineuzeLaag)
-        WHERE NOT EXISTS((b)-[:LigtOp]->(:Onderbouw))
-        RETURN b.uuid as uuid, b.name as name"""
+            MATCH (b:BitumineuzeLaag {isActief: TRUE})
+            WHERE NOT EXISTS((b)-[:LigtOp]->(:Onderbouw {isActief: TRUE}))
+            RETURN b.uuid AS uuid, b.toestand AS toestand
+        """
 
     def run_report(self, sender):
         self.report.run_report(sender=sender)

--- a/Reports/Report0046.py
+++ b/Reports/Report0046.py
@@ -1,0 +1,21 @@
+from DQReport import DQReport
+
+
+class Report0046:
+    def __init__(self):
+        self.report = None
+
+    def init_report(self):
+        self.report = DQReport(name='report0046',
+                               title='Een Onderbouw heeft steeds een ligtOp relatie naar een Geotextiel',
+                               spreadsheet_id='',
+                               datasource='Neo4J',
+                               persistent_column='C')
+
+        self.report.result_query = """
+        MATCH (o:Onderbouw)
+        WHERE NOT EXISTS((o)-[:LigtOp]->(:Geotextiel))
+        RETURN o.uuid as uuid, o.name as name"""
+
+    def run_report(self, sender):
+        self.report.run_report(sender=sender)

--- a/Reports/Report0046.py
+++ b/Reports/Report0046.py
@@ -13,9 +13,10 @@ class Report0046:
                                persistent_column='C')
 
         self.report.result_query = """
-        MATCH (o:Onderbouw)
-        WHERE NOT EXISTS((o)-[:LigtOp]->(:Geotextiel))
-        RETURN o.uuid as uuid, o.name as name"""
+            MATCH (o:Onderbouw {isActief: TRUE})
+            WHERE NOT EXISTS((o)-[:LigtOp]->(:Geotextiel {isActief: TRUE}))
+            RETURN o.uuid as uuid, o.toestand as toestand
+        """
 
     def run_report(self, sender):
         self.report.run_report(sender=sender)

--- a/Reports/Report0047.py
+++ b/Reports/Report0047.py
@@ -1,0 +1,39 @@
+from DQReport import DQReport
+
+
+class Report0047:
+    def __init__(self):
+        self.report = None
+
+    def init_report(self):
+        self.report = DQReport(name='report0047',
+                               title='(Experimenteel) Wanneer een BitumineuzeLaag geometrisch op een Onderbouw ligt, dan is er een LigtOp relatie van die BitumineuzeLaag naar die Onderbouw.',
+                               spreadsheet_id='',
+                               datasource='PostGIS',
+                               persistent_column='C')
+
+        self.report.result_query = """
+            WITH a_bl AS (
+                SELECT *
+                FROM assets a
+                INNER JOIN geometrie g ON (g.assetuuid = a.uuid)
+                WHERE a.assettype = '3d24792a-6941-481b-9c8c-739309fd3ffb')
+            , a_ob AS (
+                SELECT *
+                FROM assets a
+                INNER JOIN geometrie g ON (g.assetuuid = a.uuid)
+                WHERE a.assettype = '3d24792a-6941-481b-9c8c-739309fd3ffb')
+            SELECT a_bl_prime.uuid AS uuid_bitumineuze_laag, a_ob_prime AS uuid_onderbouw
+            FROM a_bl AS a_bl_prime, a_ob AS a_ob_prime
+            WHERE ST_Intersects(ST_GeogFromText(a_bl_prime.wkt_string), ST_GeogFromText(a_ob_prime.wkt_string))
+            AND NOT exists (
+                SELECT 1
+                FROM a_bl, a_ob
+                INNER JOIN assetrelaties a_r ON (a_r.bronuuid = a_bl_prime.uuid AND a_r.doeluuid = a_ob_prime.uuid)
+                WHERE a_r.relatietype = '321c18b8-92ca-4188-a28a-f00cdfaa0e31'
+                LIMIT 1
+            )
+        """
+
+    def run_report(self, sender):
+        self.report.run_report(sender=sender)

--- a/Reports/Report0047.py
+++ b/Reports/Report0047.py
@@ -7,30 +7,33 @@ class Report0047:
 
     def init_report(self):
         self.report = DQReport(name='report0047',
-                               title='(Experimenteel) Wanneer een BitumineuzeLaag geometrisch op een Onderbouw ligt, dan is er een LigtOp relatie van die BitumineuzeLaag naar die Onderbouw.',
+                               title='Wanneer een BitumineuzeLaag geometrisch op een Onderbouw ligt, dan zijn deze assets verbonden door een LigtOp relatie van BitumineuzeLaag naar Onderbouw.',
                                spreadsheet_id='',
                                datasource='PostGIS',
                                persistent_column='C')
 
         self.report.result_query = """
-            WITH a_bl AS (
-                SELECT *
+            WITH a_bl as (
+                SELECT a.uuid, g.wkt_string
                 FROM assets a
+                INNER JOIN assettypes a_t ON (a.assettype = a_t.uuid)
                 INNER JOIN geometrie g ON (g.assetuuid = a.uuid)
-                WHERE a.assettype = '3d24792a-6941-481b-9c8c-739309fd3ffb')
+                WHERE a_t.uri = 'https://wegenenverkeer.data.vlaanderen.be/ns/onderdeel#BitumineuzeLaag')
             , a_ob AS (
-                SELECT *
+                SELECT a.uuid, g.wkt_string 
                 FROM assets a
+                INNER JOIN assettypes a_t ON (a.assettype = a_t.uuid)
                 INNER JOIN geometrie g ON (g.assetuuid = a.uuid)
-                WHERE a.assettype = '3d24792a-6941-481b-9c8c-739309fd3ffb')
-            SELECT a_bl_prime.uuid AS uuid_bitumineuze_laag, a_ob_prime AS uuid_onderbouw
+                WHERE a_t.uri = 'https://wegenenverkeer.data.vlaanderen.be/ns/onderdeel#Onderbouw')
+            SELECT a_bl_prime.uuid AS uuid_bitumineuze_laag, a_ob_prime.uuid AS uuid_onderbouw
             FROM a_bl AS a_bl_prime, a_ob AS a_ob_prime
             WHERE ST_Intersects(ST_GeogFromText(a_bl_prime.wkt_string), ST_GeogFromText(a_ob_prime.wkt_string))
-            AND NOT exists (
+            AND NOT EXISTS (
                 SELECT 1
                 FROM a_bl, a_ob
                 INNER JOIN assetrelaties a_r ON (a_r.bronuuid = a_bl_prime.uuid AND a_r.doeluuid = a_ob_prime.uuid)
-                WHERE a_r.relatietype = '321c18b8-92ca-4188-a28a-f00cdfaa0e31'
+                INNER JOIN relatietypes r_t ON (a_r.relatietype = r_t.uuid)
+                WHERE r_t.uri = 'https://wegenenverkeer.data.vlaanderen.be/ns/onderdeel#LigtOp'
                 LIMIT 1
             )
         """

--- a/Reports/Report0048.py
+++ b/Reports/Report0048.py
@@ -1,0 +1,36 @@
+from DQReport import DQReport
+
+
+class Report0048:
+    def __init__(self):
+        self.report = None
+
+    def init_report(self):
+        self.report = DQReport(name='report0048',
+                               title='(Experimenteel) Wanneer een BitumineuzeLaag geen LigtOpt relatie heeft naar een Onderbouw, welke Onderbouw(en) liggen dan geometrisch onder deze BitumineuzeLaag.',
+                               spreadsheet_id='',
+                               datasource='PostGIS',
+                               persistent_column='C')
+
+        self.report.result_query = """
+            WITH a_bl AS (
+                SELECT *
+                FROM assets a
+                INNER JOIN geometrie g ON (g.assetuuid = a.uuid)
+                WHERE a.assettype = '3d24792a-6941-481b-9c8c-739309fd3ffb')
+            , a_ob AS (
+                SELECT *
+                FROM assets a
+                INNER JOIN geometrie g ON (g.assetuuid = a.uuid)
+                WHERE a.assettype = '3d24792a-6941-481b-9c8c-739309fd3ffb')
+            SELECT a_bl.uuid AS uuid_bitum_missing, a_ob.uuid AS uuid_onder_suggestie
+            FROM a_bl, a_ob
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM assetrelaties a_r
+                WHERE a_r.bronuuid = a_bl.uuid AND a_r.relatietype = '321c18b8-92ca-4188-a28a-f00cdfaa0e31'
+            ) AND ST_Intersects(ST_GeogFromText(a_bl.wkt_string), ST_GeogFromText(a_ob.wkt_string))
+        """
+
+    def run_report(self, sender):
+        self.report.run_report(sender=sender)


### PR DESCRIPTION
Deze PR voegt volgende 4 rapporten toe:

- **`Report0045`**: 'Een BitumineuzeLaag heeft steeds een ligtOp relatie naar een Onderbouw.'
- **`Report0046`**: 'Een Onderbouw heeft steeds een ligtOp relatie naar een Geotextiel.'
- **`Report0047`**: 'Wanneer een BitumineuzeLaag geometrisch op een Onderbouw ligt, dan zijn deze assets verbonden door een LigtOp relatie van BitumineuzeLaag naar Onderbouw.'
- **`Report0048`**: 'BitumineuzeLaag heeft steeds een LigtOp relatie naar een Onderbouw. Wanneer niet aan deze voorwaarde voldaan is, geeft dit rapport een aantal suggesties voor Onderbouwen adhv de geometrie.'

Deze rapporten zijn op vraag van Arthur Tilkens.