### PR TITLE
Update Report0108 Multipart geometry

### DIFF
--- a/Reports/Report0108.py
+++ b/Reports/Report0108.py
@@ -35,6 +35,7 @@ class Report0108:
         from cte_geom_multiparts g
         LEFT JOIN assets a ON g.assetuuid = a.uuid
         LEFT JOIN assettypes at ON a.assettype = at.uuid
+        where at.URI !~ '^(https://grp.).*' -- Regular expression does not start with 
         """
 
     def run_report(self, sender):


### PR DESCRIPTION
Toevoegen van een filter: typeURI van de asset start niet met 'https://grp.'.