### PR TITLE
Update Report0171

### DIFF
--- a/Reports/Report0171.py
+++ b/Reports/Report0171.py
@@ -77,7 +77,7 @@ class Report0171:
                 , a.assettype
                 , lookup.assetnaam
                 , lookup.regexp_pattern
-                , regexp_like(a.naam, lookup.regexp_pattern) as naamconventie	 -- boolean check on regular expression
+                , a.naam ~ lookup.regexp_pattern as naamconventie	 -- boolean check on regular expression
             from assets a
             inner join cte_lookup_table lookup on a.assettype = lookup.assettype
             where


### PR DESCRIPTION
Replace function regexp_like() with tilde-symbol ~. Function is only available from PostGIS version 15 onwards, so ~ operator is used to check the regular expression match. Case-sensitive pattern matching.